### PR TITLE
Removing improper usage of `var` vs. `const`

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,21 +85,21 @@ Arrow functions are a short-hand notation for writing functions in ES6. The arro
 
 ```javascript
 // Classical Function Expression
-let addition = function(a, b) {
+function addition(a, b) {
     return a + b;
 };
 
 // Implementation with arrow function
-let addition = (a, b) => a + b;
+const addition = (a, b) => a + b;
 ```
 Note that in the above example, the `addition` arrow function is implemented with "concise body" which does not need an explicit return statement.
 
 Here is an example with the usual "block body"
 
 ```javascript
-let arr = ['apple', 'banana', 'orange'];
+const arr = ['apple', 'banana', 'orange'];
 
-let breakfast = arr.map(fruit => {
+const breakfast = arr.map(fruit => {
     return fruit + 's';
 });
 
@@ -131,7 +131,7 @@ In ECMAScript 3/5, this issue was fixed by assigning the value in `this` to a va
 
 ```javascript
 function Person() {
-    var self = this;
+    const self = this;
     self.age = 0;
 
     setInterval(function growUp() {
@@ -155,7 +155,7 @@ function Person() {
     }, 1000);
 }
 
-var p = new Person();
+let p = new Person();
 ```
 [Read more about 'Lexical this' in arrow functions here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions#No_binding_of_this)
 
@@ -166,7 +166,7 @@ var p = new Person();
 ES6 allows you to set default parameters in function definitions. Here is a simple illustration.
 
 ```javascript
-let getFinalPrice = (price, tax = 0.7) => price + price * tax;
+const getFinalPrice = (price, tax = 0.7) => price + price * tax;
 getFinalPrice(500); // 850
 ```
 
@@ -284,13 +284,13 @@ console.log(a, b, c); // 4 5 6
 ES6 allows to use `super` method in (classless) objects with prototypes. Following is a simple example:
 
 ```javascript
-var parent = {
+const parent = {
     foo() {
         console.log("Hello from the Parent");
     }
 }
 
-var child = {
+const child = {
     foo() {
         super.foo();
         console.log("Hello from the Child");
@@ -322,7 +322,7 @@ console.log(`Hi ${user}!`); // Hi Kevin!
 * `for...of` iterates over iterable objects, such as array.
 
 ```javascript
-let nicknames = ['di', 'boo', 'punkeye'];
+const nicknames = ['di', 'boo', 'punkeye'];
 nicknames.size = 3;
 for (let nickname of nicknames) {
     console.log(nickname);
@@ -335,7 +335,7 @@ for (let nickname of nicknames) {
 * `for...in` iterates over all enumerable properties of an object.
 
 ```javascript
-let nicknames = ['di', 'boo', 'punkeye'];
+const nicknames = ['di', 'boo', 'punkeye'];
 nicknames.size = 3;
 for (let nickname in nicknames) {
     console.log(nickname);
@@ -355,9 +355,9 @@ ES6 introduces new set of data structures called `Map` and `WeakMap`. Now, we ac
 An object is made of keys (always strings) and values, whereas in `Map`, any value (both objects and primitive values) may be used as either a key or a value. Have a look at this piece of code:
 
 ```javascript
-var myMap = new Map();
+const myMap = new Map();
 
-var keyString = "a string",
+const keyString = "a string",
     keyObj = {},
     keyFunc = () => {};
 
@@ -383,11 +383,11 @@ Another thing to note here- in `WeakMap` as opposed to `Map` *every key must be 
 A `WeakMap` only has four methods `delete(key)`, `has(key)`, `get(key)` and `set(key, value)`.
 
 ```javascript
-let w = new WeakMap();
+const w = new WeakMap();
 w.set('a', 'b');
 // Uncaught TypeError: Invalid value used as weak map key
 
-var o1 = {},
+const o1 = {},
     o2 = () => {},
     o3 = window;
 
@@ -409,7 +409,7 @@ w.has(o1); // false
 *Set* objects are collections of unique values. Duplicate values are ignored, as the collection must have all unique values. The values can be primitive types or object references.
 
 ```javascript
-let mySet = new Set([1, 1, 2, 2, 3, 3]);
+const mySet = new Set([1, 1, 2, 2, 3, 3]);
 mySet.size; // 3
 mySet.has(1); // true
 mySet.add('strings');
@@ -444,9 +444,9 @@ Sets also have the `delete()` and `clear()` methods.
 Similar to `WeakMap`, the `WeakSet` object lets you store weakly held *objects* in a collection. An object in the `WeakSet` occurs only once; it is unique in the WeakSet's collection.
 
 ```javascript
-var ws = new WeakSet();
-var obj = {};
-var foo = {};
+const ws = new WeakSet();
+const obj = {};
+const foo = {};
 
 ws.add(window);
 ws.add(obj);
@@ -484,7 +484,7 @@ class Task {
 }
 
 console.log(typeof Task); // function
-let task = new Task(); // "task instantiated!"
+const task = new Task(); // "task instantiated!"
 task.showId(); // 23
 Task.loadAll(); // "Loading all tasks.."
 ```
@@ -532,7 +532,7 @@ A `Symbol` is a unique and immutable data type introduced in ES6. The purpose of
 Here’s how you create a symbol:
 
 ```javascript
-var sym = Symbol("some optional description");
+const sym = Symbol("some optional description");
 console.log(typeof sym); // symbol
 ```
 
@@ -541,7 +541,7 @@ Note that you cannot use `new` with `Symbol(…)`.
 If a symbol is used as a property/key of an object, it’s stored in a special way that the property will not show up in a normal enumeration of the object’s properties.
 
 ```javascript
-var o = {
+const o = {
     val: 10,
     [Symbol("random")]: "I'm a symbol",
 };
@@ -563,8 +563,8 @@ ES6 has `Symbol.iterator` which specifies the default iterator for an object. Wh
 Let’s look at an array, which is an iterable, and the iterator it can produce to consume its values:
 
 ```javascript
-var arr = [11,12,13];
-var itr = arr[Symbol.iterator]();
+const arr = [11,12,13];
+const itr = arr[Symbol.iterator]();
 
 itr.next(); // { value: 11, done: false }
 itr.next(); // { value: 12, done: false }
@@ -586,13 +586,13 @@ It is written using the new `*` syntax as well as the new `yield` keyword introd
 
 ```javascript
 function *infiniteNumbers() {
-    var n = 1;
+    let n = 1;
     while (true) {
         yield n++;
     }
 }
 
-var numbers = infiniteNumbers(); // returns an iterable object
+const numbers = infiniteNumbers(); // returns an iterable object
 
 numbers.next(); // { value: 1, done: false }
 numbers.next(); // { value: 2, done: false }
@@ -612,7 +612,7 @@ ES6 has native support for promises. A *promise* is an object that is waiting fo
 The standard way to create a Promise is by using the `new Promise()` constructor which accepts a handler that is given two functions as parameters. The first handler (typically named `resolve`) is a function to call with the future value when it's ready; and the second handler (typically named `reject`) is a function to call to reject the Promise if it can't resolve the future value.
 
 ```javascript
-var p = new Promise((resolve, reject) => {  
+const p = new Promise((resolve, reject) => {  
     if (/* condition */) {
         resolve(/* value */);  // fulfilled successfully
     } else {
@@ -631,7 +631,7 @@ p.then((val) => console.log("Promise Resolved", val),
 Returning a value from `then` callbacks will pass the value to the next `then` callback.
 
 ```javascript
-var hello = new Promise((resolve, reject) => { resolve("Hello") });
+const hello = new Promise((resolve, reject) => { resolve("Hello") });
 
 hello.then((str) => `${str} World`)
      .then((str) => `${str}!`)
@@ -642,9 +642,9 @@ When returning a promise, the resolved value of the promise will get passed to t
 This is a simple technique to avoid "callback hell".
 
 ```javascript
-var p = new Promise((resolve, reject) => { resolve(1) });
+const p = new Promise((resolve, reject) => { resolve(1) });
 
-var eventuallyAdd1 = (val) => new Promise((resolve, reject) => { resolve(val + 1) });
+const eventuallyAdd1 = (val) => new Promise((resolve, reject) => { resolve(val + 1) });
 
 p.then(eventuallyAdd1)
  .then(eventuallyAdd1)


### PR DESCRIPTION
It's best to use const **in every case where you won't re-assign the _entire_ variable.**

V8 has to do **a lot of work** to handle when a variable is re-assigned - especially when it's going to a differing type (int16 to int 32 or array to string, etc)

Using `const` by default let's us optimize away very slow anti-patterns. 

`const`'s allow the engine to ignore tons of boxing/unboxing type operations.